### PR TITLE
Document NGN Verve card issuance and PIN management

### DIFF
--- a/api-reference/cards/create.mdx
+++ b/api-reference/cards/create.mdx
@@ -3,6 +3,16 @@ title: 'Create Card'
 openapi: 'POST /cards'
 ---
 
+Create a virtual card for an approved customer. Card currency and issuer must use one of these supported combinations:
+
+| Currency | Issuer | Supported type |
+| --- | --- | --- |
+| USD | `VISA` | `DEFAULT`, `LITE`, or `COOPERATE` |
+| USD | `MASTERCARD` | `LITE` |
+| NGN | `VERVE` | `DEFAULT` |
+
+NGN Verve cards are charged an issuance fee of NGN 1,000 in addition to the initial card balance. The declined transaction fee is NGN 500. Card funding, withdrawal, and termination fees are currently zero. After issuance succeeds, set the card PIN using the [Set Card PIN](/api-reference/cards/set-pin) endpoint.
+
 <RequestExample>
 
 ```bash cURL
@@ -11,9 +21,9 @@ curl -X POST https://api.swervpay.co/api/v1/cards \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "user",
-    "currency": "USD",
-    "provider": "MASTERCARD",
-    "amount": 10,
+    "currency": "NGN",
+    "issuer": "VERVE",
+    "amount": 1000,
     "type": "DEFAULT"
   }'
 ```
@@ -30,9 +40,9 @@ const swervpay = new SwervpayClient(config);
 
 await swervpay.card.create({
     customer_id: "user",
-    currency: "USD",
-    provider: "MASTERCARD",
-    amount: 10,
+    currency: "NGN",
+    issuer: "VERVE",
+    amount: 1000,
     type: "DEFAULT"
 })
 ```
@@ -49,9 +59,9 @@ $client = new Swervpay($config);
 
 $client->card()->create([
     "customer_id" => "user",
-    "currency" => "USD",
-    "provider" => "MASTERCARD",
-    "amount" => 10,
+    "currency" => "NGN",
+    "issuer" => "VERVE",
+    "amount" => 1000,
     "type" => "DEFAULT"
 ]);
 ```
@@ -77,10 +87,10 @@ func main() {
 
     data := swervpay.CreateCardBody{
         Type: "DEFAULT",
-        Currency: "USD",
-        Provider: "MASTERCARD",
+        Currency: "NGN",
+        Issuer: "VERVE",
         CustomerId: "user",
-        Amount: 10
+        Amount: 1000
     }
 
 	resp, err := client.Card.Create(ctx, data)
@@ -94,3 +104,4 @@ func main() {
 
 </RequestExample>
 
+`amount` is expressed in the currency's major unit. For example, `1000` means NGN 1,000, not 1,000 kobo.

--- a/api-reference/cards/set-pin.mdx
+++ b/api-reference/cards/set-pin.mdx
@@ -1,0 +1,23 @@
+---
+title: 'Set Card PIN'
+openapi: 'PATCH /cards/{id}/pin'
+---
+
+Set or update the four-digit PIN for an active NGN Verve card. Call this endpoint after the `card.created` webhook confirms that issuance completed successfully.
+
+<RequestExample>
+
+```bash cURL
+curl -X PATCH https://api.swervpay.co/api/v1/cards/card_123/pin \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pin": "1234"
+  }'
+```
+
+</RequestExample>
+
+<Note>
+The PIN must contain exactly four digits. Swerv does not return the PIN in API responses or card webhooks.
+</Note>

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -881,6 +881,76 @@
                 }
             }
         },
+        "/cards/{id}/pin": {
+            "patch": {
+                "description": "Set or update the PIN for an NGN Verve card",
+                "operationId": "setCardPin",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OpenapiSetCardPinRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccessResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UsererrorError"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UsererrorError"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UsererrorError"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "tags": [
+                    "card.pin"
+                ]
+            }
+        },
         "/cards/{id}/regularize": {
             "post": {
                 "tags": [
@@ -3376,6 +3446,14 @@
                         "$ref": "#/components/schemas/TypesBusinessTransaction"
                     }
                 }
+            },
+            "OpenapiSetCardPinRequest": {
+                "properties": {
+                    "pin": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "OpenapiUpdateInvoiceRequest": {
                 "type": "object",

--- a/card/introduction.mdx
+++ b/card/introduction.mdx
@@ -129,8 +129,8 @@ Initiate the creation of a virtual or physical card by sending a request to the 
  The cardholder name that may appear on the card.
 </ParamField>
 
-<ParamField body="provider" type="string" required>
- card provider e.g MASTERCARD, VISA
+<ParamField body="issuer" type="string" required>
+ Card issuer. Use `VISA` or `MASTERCARD` for USD cards and `VERVE` for NGN cards.
 </ParamField>
 
 <ParamField body="type" type="string" required>
@@ -138,7 +138,7 @@ Initiate the creation of a virtual or physical card by sending a request to the 
 </ParamField>
 
 <ParamField body="amount" type="integer">
- amount to pre-fund the card
+ Amount to pre-fund the card, expressed in the currency's major unit.
 </ParamField>
 
 <ParamField body="expiry_date" type="string">
@@ -173,6 +173,12 @@ Document type of the company (for lite card type only)
 <Note>
 Note: `customer_id` is required for DEFAULT card type
 </Note>
+
+<Note>
+NGN cards use `currency: "NGN"`, `issuer: "VERVE"`, and `type: "DEFAULT"`. Set the four-digit PIN after issuance using the [Set Card PIN](/api-reference/cards/set-pin) endpoint.
+</Note>
+
+NGN Verve card pricing currently includes an NGN 1,000 issuance fee and an NGN 500 declined transaction fee. Funding, withdrawal, and termination fees are zero until further notice.
 
 **Request Body**
 

--- a/mint.json
+++ b/mint.json
@@ -159,6 +159,7 @@
         "api-reference/cards/get-all-cards",
         "api-reference/cards/get",
         "api-reference/cards/create",
+        "api-reference/cards/set-pin",
         "api-reference/cards/fund-card",
         "api-reference/cards/withdraw-from-card",
         "api-reference/cards/freeze",


### PR DESCRIPTION
## Summary
- document NGN Verve card issuance and lifecycle behavior
- document the card PIN endpoint and request format
- record default NGN pricing: NGN 1,000 issuance, NGN 500 decline, and zero funding, withdrawal, and termination fees
- add the PIN operation to the OpenAPI specification and Mintlify navigation

## Validation
- OpenAPI and Mintlify JSON validated
- documentation diff checked for whitespace errors